### PR TITLE
build: make docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,8 @@ lint:
 build:
 	@echo "--> Building the binary and saving in bin/supply-server"
 	@go build -o bin/supply-server
+
+## docker-build: Build a docker image. Requires docker to be installed.
+docker-build:
+	@echo "--> Building the docker image"
+	@docker build . --tag "celestiaorg/supply:latest"


### PR DESCRIPTION
I want CI to auto-generate Docker images for this repo. I think a prerequisite to that is adding a Makefile command that so that the Docker image generated in CI and locally is created with the same command.