### PR TITLE
fix: architecture for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 RUN GOOS=linux GOARCH=amd64 go build -o main .
 
 # Stage 2: Create the runtime image
-FROM docker.io/alpine:3.18.4
+FROM --platform=linux/amd64 docker.io/alpine:3.18.4
 
 RUN apk update && apk add --no-cache bash curl jq
 COPY --from=builder /app/main .


### PR DESCRIPTION
Closes https://github.com/celestiaorg/supply/issues/22

## Testing

```
make docker-build

docker inspect celestiaorg/supply

        "Architecture": "amd64",
        "Os": "linux",
```