### PR TITLE
fix: year one unlock date

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/supply
 
-go 1.21.3
+go 1.22.6
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/internal/circulating_supply_test.go
+++ b/internal/circulating_supply_test.go
@@ -15,7 +15,7 @@ func TestCirculatingSupply(t *testing.T) {
 	testCases := []testCase{
 		{oneHourBeforeTGE, 0},
 		{TGE, 141_043_527_750_000},
-		{oneYearAfterTGE, 399_419_057_601_768},
+		{oneYearAfterTGE, 398_395_290_749_715},
 		{twoYearsAfterTGE, 839_606_500_049_419},
 		{threeYearsAfterTGE, 1_040_234_519_080_896},
 		{fourYearsAfterTGE, 1_178_923_710_072_480},
@@ -55,7 +55,8 @@ func Test_investorsCirculating(t *testing.T) {
 		{oneHourBeforeTGE, 0},
 		{TGE, 0},
 		{oneDayAfterTGE, 0},
-		{oneYearAfterTGE, 119_212_799_030_136},
+		{oneYearAfterTGEMinusOneDay, 0},       // one day before tokens unlock.
+		{oneYearAfterTGE, investorsTotal / 3}, // tokens unlock on October 30th, 2024.
 		{twoYearsAfterTGE, investorsTotal},
 		{threeYearsAfterTGE, investorsTotal},
 		{fourYearsAfterTGE, investorsTotal},
@@ -77,7 +78,8 @@ func Test_coreContributorsCirculating(t *testing.T) {
 		{oneHourBeforeTGE, 0},
 		{TGE, 0},
 		{oneDayAfterTGE, 0},
-		{oneYearAfterTGE, 58_949_689_726_027},
+		{oneYearAfterTGEMinusOneDay, 0},         // one day before tokens unlock.
+		{oneYearAfterTGE, coreContributors / 3}, // tokens unlock on October 30th, 2024.
 		{twoYearsAfterTGE, 117_738_314_725_882},
 		{threeYearsAfterTGE, coreContributors},
 		{fourYearsAfterTGE, coreContributors},

--- a/internal/dates.go
+++ b/internal/dates.go
@@ -3,10 +3,14 @@ package internal
 import "time"
 
 var (
-	oneHourBeforeTGE   = time.Date(2023, time.October, 31, 13, 0, 0, 0, time.UTC)
-	TGE                = time.Date(2023, time.October, 31, 14, 0, 0, 0, time.UTC)
-	oneDayAfterTGE     = TGE.AddDate(0, 0, 1)
-	oneYearAfterTGE    = TGE.AddDate(1, 0, 0)
+	oneHourBeforeTGE           = time.Date(2023, time.October, 31, 13, 0, 0, 0, time.UTC)
+	TGE                        = time.Date(2023, time.October, 31, 14, 0, 0, 0, time.UTC)
+	oneDayAfterTGE             = TGE.AddDate(0, 0, 1)
+	oneYearAfterTGEMinusOneDay = TGE.AddDate(0, 0, 364) // October 29, 2024
+	oneYearAfterTGE            = TGE.AddDate(0, 0, 365) // October 30, 2024
+
+	// TODO: verify these dates. The unlock dates may not be exactly N years
+	// after TGE. Instead, they may be N * 365 days after.
 	twoYearsAfterTGE   = TGE.AddDate(2, 0, 0)
 	threeYearsAfterTGE = TGE.AddDate(3, 0, 0)
 	fourYearsAfterTGE  = TGE.AddDate(4, 0, 0)

--- a/internal/total_supply_test.go
+++ b/internal/total_supply_test.go
@@ -16,7 +16,7 @@ func TestTotalSupply(t *testing.T) {
 		{oneHourBeforeTGE, 0},
 		{TGE, initialTotalSupplyInUtia},
 		{oneDayAfterTGE, 1000219178082191},
-		{oneYearAfterTGE, 1080213041095605},
+		{oneYearAfterTGE, 1079999999999715},
 		{twoYearsAfterTGE, 1157965542048880},
 		{threeYearsAfterTGE, 1232979823056239},
 		{fourYearsAfterTGE, 1304866360072480},


### PR DESCRIPTION
## Motivation

See [Slack thread](https://celestia-team.slack.com/archives/C0650EDESBY/p1725866590013359).  

You can verify the year one unlock date by looking at a vesting account on Mintscan:

![screenshot](https://github.com/user-attachments/assets/f3d39766-ef41-4f87-9572-e6916553965b)

## FLUPs

https://github.com/celestiaorg/supply/issues/35