### PR TITLE
fix: docker build by bumping Go version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
       branches:
         - main
 
-env:
-  GO_VERSION: '1.21.3'
-
 jobs:
   docker-build:
     name: docker-build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: lint
 on:
   pull_request:
 
-env:
-  GO_VERSION: '1.21.3'
-
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -14,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           # This job will pass without running if go.mod, go.sum, and *.go
@@ -23,9 +20,9 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: golangci/golangci-lint-action@v3.7.0
+      - uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.54.2
+          version: v1.61.0
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,14 @@ name: test
 on:
     pull_request:
 
-
-env:
-  GO_VERSION: '1.21.3'
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
-
+          go-version-file: 'go.mod'
       - name: Run tests
         run: make test
         timeout-minutes: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 docker.io/golang:1.21-alpine3.18 AS builder
+FROM --platform=linux/amd64 docker.io/golang:1.22-alpine3.18 AS builder
 
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on


### PR DESCRIPTION
Fixes https://github.com/celestiaorg/supply/issues/36 and bumps the versions of Github CI actions