### PR TITLE
fix: circulating supply API response on Oct 30

### DIFF
--- a/internal/circulating_supply_test.go
+++ b/internal/circulating_supply_test.go
@@ -15,7 +15,9 @@ func TestCirculatingSupply(t *testing.T) {
 	testCases := []testCase{
 		{oneHourBeforeTGE, 0},
 		{TGE, 141_043_527_750_000},
+		{oneYearAfterTGEMinusOneDay, 220_824_349_667_524},
 		{oneYearAfterTGE, 398_395_290_749_715},
+		{oneYearAfterTGEPlusOneDay, 399_602_581_376_425},
 		{twoYearsAfterTGE, 839_606_500_049_419},
 		{threeYearsAfterTGE, 1_040_234_519_080_896},
 		{fourYearsAfterTGE, 1_178_923_710_072_480},

--- a/internal/dates.go
+++ b/internal/dates.go
@@ -3,11 +3,12 @@ package internal
 import "time"
 
 var (
-	oneHourBeforeTGE           = time.Date(2023, time.October, 31, 13, 0, 0, 0, time.UTC)
-	TGE                        = time.Date(2023, time.October, 31, 14, 0, 0, 0, time.UTC)
+	oneHourBeforeTGE           = time.Date(2023, time.October, 30, 23, 0, 0, 0, time.UTC)
+	TGE                        = time.Date(2023, time.October, 31, 0, 0, 0, 0, time.UTC)
 	oneDayAfterTGE             = TGE.AddDate(0, 0, 1)
 	oneYearAfterTGEMinusOneDay = TGE.AddDate(0, 0, 364) // October 29, 2024
 	oneYearAfterTGE            = TGE.AddDate(0, 0, 365) // October 30, 2024
+	oneYearAfterTGEPlusOneDay  = TGE.AddDate(0, 0, 366) // October 31, 2024
 
 	// TODO: verify these dates. The unlock dates may not be exactly N years
 	// after TGE. Instead, they may be N * 365 days after.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/supply/issues/56

The problem was that the code used the exact hour that TGE occurred (October 31, 2023 @ 2PM UTC). The API only operates on days so when the API request for 

```
http://0.0.0.0:8080/v0/circulating-supply?date=2024-10-30
```

was received, it parsed that as a date only which didn't contain the hours. The resolution was to remove the hours from TGE and operate only on whole dates.

## Testing

http://0.0.0.0:8080/v0/circulating-supply?date=2024-10-30 returns `398395290.749715` 
http://0.0.0.0:8080/v0/circulating-supply?date=2024-10-31 returns `399602581.376425`