### PR TITLE
feat: account for CIP-29 

### DIFF
--- a/internal/circulating_supply_test.go
+++ b/internal/circulating_supply_test.go
@@ -18,9 +18,9 @@ func TestCirculatingSupply(t *testing.T) {
 		{oneYearAfterTGEMinusOneDay, 220_824_349_667_524},
 		{oneYearAfterTGE, 398_395_290_749_715},
 		{oneYearAfterTGEPlusOneDay, 399_602_581_376_425},
-		{twoYearsAfterTGE, 839_606_500_049_419},
-		{threeYearsAfterTGE, 1_040_234_519_080_896},
-		{fourYearsAfterTGE, 1_178_923_710_072_480},
+		{twoYearsAfterTGE, 833432444153745},
+		{threeYearsAfterTGE, 1012776091200567},
+		{fourYearsAfterTGE, 1132047396704536},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.time.String(), func(t *testing.T) {

--- a/internal/dates.go
+++ b/internal/dates.go
@@ -12,7 +12,7 @@ var (
 
 	// TODO: CIP-29 hasn't activated on Mainnet yet. It will activate when v4
 	// activates on Mainnet so this date needs to be updated.
-	// cip29ActivationDate = time.Date(2025, time.July, 31, 0, 0, 0, 0, time.UTC)
+	cip29ActivationDate = time.Date(2025, time.July, 28, 0, 0, 0, 0, time.UTC)
 
 	// TODO: verify these dates. The unlock dates may not be exactly N years
 	// after TGE. Instead, they may be N * 365 days after.

--- a/internal/dates.go
+++ b/internal/dates.go
@@ -10,8 +10,9 @@ var (
 	oneYearAfterTGE            = TGE.AddDate(0, 0, 365) // October 30, 2024
 	oneYearAfterTGEPlusOneDay  = TGE.AddDate(0, 0, 366) // October 31, 2024
 
-	// TODO: CIP-29 hasn't activated on Mainnet yet. It will activate when v4
-	// activates on Mainnet so this date needs to be updated.
+	// CIP-29 activates on Mainnet at the v4 activation height height (6680339).
+	// This is an estimate for the date of activation.
+	// See https://www.mintscan.io/celestia/block/6680339
 	cip29ActivationDate = time.Date(2025, time.July, 28, 0, 0, 0, 0, time.UTC)
 
 	// TODO: verify these dates. The unlock dates may not be exactly N years

--- a/internal/inflation.go
+++ b/internal/inflation.go
@@ -11,13 +11,12 @@ const (
 )
 
 const (
-	// Genesis era (before CIP-29)
+	// Genesis era (before CIP-29 activation in celestia-app app verrsion 4)
 	genesisInflationRate    = 0.08
 	genesisDisinflationRate = 0.1
-	// CIP-29 era (after CIP-29 activation)
+	// CIP-29 era (after CIP-29 activation in celestia-app app version 4)
 	cip29InflationRate    = 0.0536
 	cip29DisinflationRate = 0.067
-
 	// targetInflationRate is the inflation rate that the network aims to
 	// stabalize at. In practice, TargetInflationRate acts as a minimum so that
 	// the inflation rate doesn't decrease after reaching it.

--- a/internal/inflation_test.go
+++ b/internal/inflation_test.go
@@ -82,9 +82,9 @@ func Test_annualProvisions(t *testing.T) {
 	testCases := []testCase{
 		{TGE, 80000000000000},
 		{TGE.Add(1 * year), 77760000000000},
-		{TGE.Add(2 * year), 75022848000000},
-		{TGE.Add(3 * year), 71895895695360},
-		{TGE.Add(20 * year), 30075034732276},
+		{TGE.Add(2 * year), 54018766080000},
+		{TGE.Add(3 * year), 52751153244994},
+		{TGE.Add(20 * year), 28336928866935},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("time %v", tc.t), func(t *testing.T) {

--- a/internal/inflation_test.go
+++ b/internal/inflation_test.go
@@ -16,9 +16,13 @@ func Test_inflationRate(t *testing.T) {
 	testCases := []testCase{
 		{TGE, 0.08},
 		{TGE.Add(1 * year), 0.072},
-		{TGE.Add(2 * year), 0.0648},
-		{TGE.Add(3 * year), 0.05832},
-		{TGE.Add(20 * year), 0.015},
+		{cip29ActivationDate.Add(-1 * day), 0.072},
+		{cip29ActivationDate, 0.050009},
+		{cip29ActivationDate.Add(1 * day), 0.050009},
+		{TGE.Add(2 * year), 0.046658},
+		{TGE.Add(3 * year), 0.043532},
+		{TGE.Add(18 * year), 0.015383},
+		{TGE.Add(30 * year), 0.015},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("time %v", tc.t), func(t *testing.T) {

--- a/internal/inflation_test.go
+++ b/internal/inflation_test.go
@@ -16,9 +16,9 @@ func Test_inflationRate(t *testing.T) {
 	testCases := []testCase{
 		{TGE, 0.08},
 		{TGE.Add(1 * year), 0.072},
-		{cip29ActivationDate.Add(-1 * day), 0.072},
-		{cip29ActivationDate, 0.050009},
-		{cip29ActivationDate.Add(1 * day), 0.050009},
+		{cip29ActivationDate.Add(-1 * day), 0.072},   // Before CIP-29 activation
+		{cip29ActivationDate, 0.050009},              // CIP-29 activation
+		{cip29ActivationDate.Add(1 * day), 0.050009}, // After CIP-29 activation
 		{TGE.Add(2 * year), 0.046658},
 		{TGE.Add(3 * year), 0.043532},
 		{TGE.Add(18 * year), 0.015383},

--- a/internal/total_supply_test.go
+++ b/internal/total_supply_test.go
@@ -17,9 +17,9 @@ func TestTotalSupply(t *testing.T) {
 		{TGE, initialTotalSupplyInUtia},
 		{oneDayAfterTGE, 1000219178082191},
 		{oneYearAfterTGE, 1079999999999715},
-		{twoYearsAfterTGE, 1157965542048880},
-		{threeYearsAfterTGE, 1232979823056239},
-		{fourYearsAfterTGE, 1304866360072480},
+		{twoYearsAfterTGE, 1151791486153206},
+		{threeYearsAfterTGE, 1205521395175910},
+		{fourYearsAfterTGE, 1257990046704536},
 	}
 	for _, tc := range testCases {
 		got := TotalSupply(tc.time)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/supply/issues/43

Note for reviewers: the expected values in some unit tests had to be updated. The expected values should have _decreased_ because the amount of TIA minted due to inflation post CIP-29 decreased.

## Follow ups
- [ ] After this merges, ask @sysrex to update the container that runs https://supply.celestia.org/