### PR TITLE
feat: include release version in /version endpoint

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -43,3 +45,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ FROM --platform=linux/amd64 docker.io/alpine:3.18.4
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
 
+ARG VERSION
+ENV VERSION=$VERSION
+
 RUN apk update && apk add --no-cache bash curl jq
 COPY --from=builder /app/supply-server .
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,12 @@ func getTotalSupply(c *gin.Context) {
 
 func getVersion(c *gin.Context) {
 	gitCommit := os.Getenv("GIT_COMMIT")
-	c.String(200, gitCommit)
+	version := os.Getenv("VERSION")
+	if version != "" {
+		c.String(200, fmt.Sprintf("%s (%s)", version, gitCommit))
+	} else {
+		c.String(200, gitCommit)
+	}
 }
 
 // getDate returns the date from the query parameter or the current date if no


### PR DESCRIPTION
## Summary

The `/version` endpoint currently returns only the git commit hash. This change adds support for displaying the release version alongside the commit hash when building from a versioned tag.

**Before (main build):**
```
9587d9688412198f5e186e20607e449a9b40b820
```

**After (tagged release build):**
```
v1.2.3 (9587d9688412198f5e186e20607e449a9b40b820)
```

## Changes

- **`Dockerfile`** — add `VERSION` build arg and env var alongside the existing `GIT_COMMIT`
- **`main.go`** — update `getVersion` to return `VERSION (GIT_COMMIT)` when `VERSION` is set, falling back to the current behaviour otherwise
- **`docker.yml`** — trigger on `v*` tag pushes in addition to `main`, and pass `VERSION=${{ github.ref_name }}` as a build arg for tagged builds

## Notes

`main` branch builds are unaffected. The `VERSION` env var is only populated when building from a `v*` tag, so the endpoint behaviour on the current deployment does not change until the first versioned release is cut.